### PR TITLE
Refactor drill-hole ActionBar to use stable master references

### DIFF
--- a/src/ux/pages/drill-hole-data/components/ActionBar.tsx
+++ b/src/ux/pages/drill-hole-data/components/ActionBar.tsx
@@ -1,7 +1,10 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { Button } from "antd";
-import { PlusOutlined, ReloadOutlined, SaveOutlined } from "@ant-design/icons";
+import { PlusOutlined, ReloadOutlined } from "@ant-design/icons";
+import { ActionBar as MasterActionBar } from "../../../components/ActionBar";
+import type { ActionBarProps } from "../../../components/ActionBar.types";
 import { useDrillHoleDataStore } from "../store";
+import type { SectionKey } from "../types/data-contracts";
 import { getSectionKeyForTab } from "../utils/navigation";
 
 const LENSES_BY_TAB: Record<string, string[]> = {
@@ -23,18 +26,70 @@ const OTHER_LOGS_BY_TAB: Record<string, string[]> = {
 	Geology: ["Shear", "Structure"],
 };
 
+const ACTION_BUTTON_CONFIG: ActionBarProps["buttonConfig"] = {
+	save: { label: "Save" },
+	submit: { label: "Submit" },
+	review: { label: "Review" },
+	approve: { label: "Approve" },
+	reject: { label: "Reject" },
+};
+
+function getSectionRowStatus(section: any): number {
+	if (!section)
+		return 0;
+
+	if (typeof section.data?.RowStatus === "number") {
+		return section.data.RowStatus;
+	}
+
+	if (Array.isArray(section.data) && section.data.length > 0) {
+		const firstRow = section.data[0];
+		if (typeof firstRow?.RowStatus === "number") {
+			return firstRow.RowStatus;
+		}
+	}
+
+	return 0;
+}
+
 export const ActionBar: React.FC = () => {
-	const { activeTab, activeLens, setActiveLens, saveSection, refreshSection } = useDrillHoleDataStore();
+	const activeTab = useDrillHoleDataStore(state => state.activeTab);
+	const activeLens = useDrillHoleDataStore(state => state.activeLens[activeTab] ?? "");
+	const setActiveLens = useDrillHoleDataStore(state => state.setActiveLens);
+	const saveSection = useDrillHoleDataStore(state => state.saveSection);
+	const submitSection = useDrillHoleDataStore(state => state.submitSection);
+	const reviewSection = useDrillHoleDataStore(state => state.reviewSection);
+	const approveSection = useDrillHoleDataStore(state => state.approveSection);
+	const rejectSection = useDrillHoleDataStore(state => state.rejectSection);
+	const refreshSection = useDrillHoleDataStore(state => state.refreshSection);
 
 	const currentLenses = LENSES_BY_TAB[activeTab] || [];
 	const currentOtherLogs = OTHER_LOGS_BY_TAB[activeTab] || [];
-	const currentViewLens = activeLens[activeTab] || currentLenses[0] || "";
-
-	const currentSectionKey = getSectionKeyForTab(activeTab as any, currentViewLens);
+	const currentViewLens = activeLens || currentLenses[0] || "";
 	const showLogActions = ["Geology", "Geotech"].includes(activeTab);
 
+	const currentSectionKey = useMemo(
+		() => getSectionKeyForTab(activeTab as any, currentViewLens),
+		[activeTab, currentViewLens],
+	);
+
+	const sectionKey = currentSectionKey as SectionKey | undefined;
+
+	const isDirty = useDrillHoleDataStore(useCallback((state) => {
+		if (!sectionKey)
+			return false;
+		const section = state.sections[sectionKey as keyof typeof state.sections] as any;
+		return Boolean(section?.isDirty ?? section?.hasUnsavedChanges?.());
+	}, [sectionKey]));
+
+	const rowStatus = useDrillHoleDataStore(useCallback((state) => {
+		if (!sectionKey)
+			return 0;
+		const section = state.sections[sectionKey as keyof typeof state.sections] as any;
+		return getSectionRowStatus(section);
+	}, [sectionKey]));
+
 	const handleLensClick = useCallback((lens: string) => {
-		console.log("[ActionBar] Lens clicked:", { tab: activeTab, lens });
 		setActiveLens(activeTab, lens);
 	}, [activeTab, setActiveLens]);
 
@@ -47,18 +102,99 @@ export const ActionBar: React.FC = () => {
 	}, []);
 
 	const handleRefresh = useCallback(async () => {
-		console.log("[ActionBar] Refresh clicked");
-		if (currentSectionKey) {
-			await refreshSection(currentSectionKey as any);
-		}
-	}, [currentSectionKey, refreshSection]);
+		if (!sectionKey)
+			return;
+		await refreshSection(sectionKey);
+	}, [refreshSection, sectionKey]);
 
-	const handleSave = useCallback(async () => {
-		console.log("[ActionBar] Save clicked");
-		if (currentSectionKey) {
-			await saveSection(currentSectionKey as any);
+	const validate = useCallback(() => {
+		if (!sectionKey) {
+			return { canSave: false, errors: [], warnings: [] };
 		}
-	}, [currentSectionKey, saveSection]);
+		const section = useDrillHoleDataStore.getState().sections[sectionKey as keyof ReturnType<typeof useDrillHoleDataStore.getState>["sections"]] as any;
+		if (typeof section?.validate === "function") {
+			return section.validate();
+		}
+		return { canSave: true, errors: [], warnings: [] };
+	}, [sectionKey]);
+
+	const getMetadata = useCallback(() => ({
+		activeTab,
+		activeLens: currentViewLens,
+		sectionKey: sectionKey ?? null,
+	}), [activeTab, currentViewLens, sectionKey]);
+
+	const masterSection = useMemo<ActionBarProps["section"]>(() => ({
+		sectionKey: sectionKey ?? "",
+		rowStatus,
+		isDirty,
+		validate,
+		getMetadata,
+	} as ActionBarProps["section"]), [sectionKey, rowStatus, isDirty, validate, getMetadata]);
+
+	const onSave = useCallback(async () => {
+		if (!sectionKey)
+			return;
+		await saveSection(sectionKey);
+	}, [saveSection, sectionKey]);
+
+	const onSubmit = useCallback(async () => {
+		if (!sectionKey)
+			return;
+		await submitSection(sectionKey);
+	}, [sectionKey, submitSection]);
+
+	const onReview = useCallback(async () => {
+		if (!sectionKey)
+			return;
+		await reviewSection(sectionKey);
+	}, [reviewSection, sectionKey]);
+
+	const onApprove = useCallback(async () => {
+		if (!sectionKey)
+			return;
+		await approveSection(sectionKey);
+	}, [approveSection, sectionKey]);
+
+	const onReject = useCallback(async () => {
+		if (!sectionKey)
+			return;
+		await rejectSection(sectionKey);
+	}, [rejectSection, sectionKey]);
+
+	const actions = useMemo<ActionBarProps["actions"]>(() => ({
+		onSave,
+		onSubmit,
+		onReview,
+		onApprove,
+		onReject,
+	}), [onSave, onSubmit, onReview, onApprove, onReject]);
+
+	const extraActions = useMemo(() => (
+		<>
+			{showLogActions && (
+				<>
+					<Button size="small" icon={<PlusOutlined />} onClick={handleAddInterval}>Add Interval</Button>
+					<Button size="small" onClick={handleNewLog}>New Log</Button>
+				</>
+			)}
+			<Button size="small" icon={<ReloadOutlined />} onClick={handleRefresh}>Refresh</Button>
+		</>
+	), [showLogActions, handleAddInterval, handleNewLog, handleRefresh]);
+
+	const renderCountRef = useRef(0);
+	const prevMasterSectionRef = useRef<ActionBarProps["section"] | null>(null);
+	renderCountRef.current += 1;
+	const masterSectionRefChanged = prevMasterSectionRef.current !== masterSection;
+	console.log("[DrillHoleData.ActionBar][guard]", {
+		renderCount: renderCountRef.current,
+		sectionKey,
+		masterSectionRefChanged,
+	});
+
+	useEffect(() => {
+		prevMasterSectionRef.current = masterSection;
+	}, [masterSection]);
 
 	return (
 		<div className="bg-slate-50 p-3 flex justify-between items-center px-6 border-b">
@@ -111,16 +247,14 @@ export const ActionBar: React.FC = () => {
 				<div className="w-px h-6 bg-slate-300 mx-2"></div>
 			</div>
 
-			<div className="flex items-center space-x-2">
-				{showLogActions && (
-					<>
-						<Button size="small" icon={<PlusOutlined />} onClick={handleAddInterval}>Add Interval</Button>
-						<Button size="small" onClick={handleNewLog}>New Log</Button>
-					</>
-				)}
-				<Button size="small" icon={<ReloadOutlined />} onClick={handleRefresh}>Refresh</Button>
-				{currentSectionKey && <Button size="small" type="primary" icon={<SaveOutlined />} onClick={handleSave}>Save</Button>}
-			</div>
+			<MasterActionBar
+				section={masterSection}
+				actions={actions}
+				extraActions={extraActions}
+				size="small"
+				buttonConfig={ACTION_BUTTON_CONFIG}
+				showReadOnlyIndicator={false}
+			/>
 		</div>
 	);
 };


### PR DESCRIPTION
### Motivation
- Reduce unnecessary re-renders by avoiding passing mutable section objects into the shared master `ActionBar` and instead rely on narrow primitive selectors. 
- Make workflow handlers and section metadata stable so `MasterActionBar` receives stable references and memoized props. 
- Prevent inline object/func churn in JSX props to improve performance and make reference equality predictable.

### Description
- Replaced broad destructuring of the drill-hole store with narrow selectors for `activeTab`, derived `activeLens`, `sectionKey`, `isDirty`, and `rowStatus` in `src/ux/pages/drill-hole-data/components/ActionBar.tsx`.
- Built a `masterSection` object with `useMemo` from primitive dependencies and stabilized `validate`/`getMetadata` using `useCallback` so their references remain stable.
- Implemented workflow handlers `onSave`, `onSubmit`, `onReview`, `onApprove`, and `onReject` as `useCallback` and passed a memoized `actions` object to the shared `MasterActionBar` (`../../../components/ActionBar`).
- Removed inline object literals/functions from JSX by introducing `ACTION_BUTTON_CONFIG`, memoized `extraActions`, `actions`, and `masterSection`, and replaced the old inline save/refresh buttons with the `MasterActionBar` usage.
- Added a temporary guard log that reports render count, current `sectionKey`, and whether `masterSection` reference changed to aid debugging (to be removed once references are stable).

### Testing
- A Playwright-based screenshot attempt against local ports (3000/5173/8080) was run and failed with `ERR_EMPTY_RESPONSE` because no local dev server was reachable. 
- No unit or automated integration tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0f495e3c833180fa16a714dacf88)